### PR TITLE
[egs] Correct the expansion of round numbers in the tens place

### DIFF
--- a/egs/althingi/s5/local/thraxgrammar/numbers.grm
+++ b/egs/althingi/s5/local/thraxgrammar/numbers.grm
@@ -43,6 +43,10 @@ decades =   ("2".utf8 : "tuttugu".utf8)
 export numbers_20_to_99 = (decades delzero) |
   decades insand ((units_notNeutral <-3>) | (neutral_units <-4.0>));
 
+export teensplus_and_round_numbers_20_to_90 = teensplus | (decades delzero);
+
+export non_round_numbers_21_to_99 = decades insand ((units_notNeutral <-3>) | (neutral_units <-4.0>));
+
 numbers_to_99 = Optimize[ zero | (units <-0.5>) | (teensplus <-1>) | (numbers_20_to_99  <-2>)];
 
 hundreds = (((one insspace | (delone <-3.0>))
@@ -51,16 +55,16 @@ hundreds = (((one insspace | (delone <-3.0>))
 numbers_100_to_999 = Optimize[
   hundreds delzero delzero |
   (hundreds delzero insand units <-1>) |
-  (hundreds insand teensplus <-2>) |
-  (hundreds (insspace | insand) numbers_20_to_99 <-10>)]
+  (hundreds insand teensplus_and_round_numbers_20_to_90 <-2>) |
+  (hundreds insspace non_round_numbers_21_to_99 <-10>)]
 ;
 
 year = Optimize[
   ((teens insspace ("".utf8 : "hundruð".utf8)
   (delzero delzero |
   (delzero insand neutral_units <-1>) |
-  (insand teensplus <-2>) |
-  ((insspace | insand) numbers_20_to_99 <-10>)))
+  (insand teensplus_and_round_numbers_20_to_90 <-2>) |
+  (insspace non_round_numbers_21_to_99 <-10>)))
   | (neutral_units2to9 insspace ("".utf8 : "þúsund".utf8)
   delzero delzero insand neutral_units))]
 ;
@@ -71,8 +75,8 @@ tail_1000_to_9999 = Optimize[
   ("".utf8 : "þúsund".utf8)
   (delzero delzero delzero |
   (delzero delzero insand units <-4>) |
-  (delzero insand teensplus <-6>) |
-  (delzero (insspace | insand) numbers_20_to_99 <-6>) |
+  (delzero insand teensplus_and_round_numbers_20_to_90 <-6>) |
+  (delzero insspace non_round_numbers_21_to_99 <-6>) |
   ((insspace | insand) numbers_100_to_999 <-8>))]
 ;
 
@@ -93,12 +97,14 @@ numbers_100000_to_999999 = Optimize[
   tail_1000_to_9999]
 ;
 
+#ein milljón og eitt þúsund
 tail_1M_to_9M = Optimize[
   ("".utf8 : ("milljón".utf8 | "milljónar".utf8 |
   "milljónir".utf8 | "milljónum".utf8 | "milljóna".utf8 ))
   (delzero delzero delzero delzero delzero delzero |
   (delzero delzero delzero delzero delzero insand units <-4>) |
-  (delzero delzero delzero delzero (insspace | insand) (teens | numbers_20_to_99) <-6>) |
+  (delzero delzero delzero delzero insand teensplus_and_round_numbers_20_to_90 <-6>) |
+  (delzero delzero delzero delzero insspace non_round_numbers_21_to_99 <-6>) |
   (delzero delzero delzero (insspace | insand) numbers_100_to_999 <-8>) |
   (delzero delzero (insspace | insand) numbers_1000_to_9999 <-50>) |
   (delzero (insspace | insand) numbers_10000_to_99999 <-60>) |
@@ -106,7 +112,7 @@ tail_1M_to_9M = Optimize[
 ;
 
 numbers_1M_to_9M = Optimize[
-  ((units <-1>) | delone)
+  ((units_notNeutral <-1>) | delone)
   insspace
   tail_1M_to_9M]
 ;


### PR DESCRIPTION
This removes the need to use sed to add in missing "og"s and previously 1000010 was never expanded.